### PR TITLE
feat(setup) allow specifying multiple tag pairs for resources

### DIFF
--- a/src/DataCollectionModule/DataCollectionModule.yaml
+++ b/src/DataCollectionModule/DataCollectionModule.yaml
@@ -40,7 +40,7 @@ Parameters:
 Outputs:
   HeidiQSDataSourceArn:
     Condition: DeployDataCollectionComponents
-    Value: !GetAtt HeidiQSDataSource.Arn
+    Value: !GetAtt HeidiQSDataSourceV2.Arn
     Export:
       Name: !Sub ${ResourcePrefix}QSDataSourceArn     
   HeidiDataCollectionDB:
@@ -352,7 +352,7 @@ Resources:
         Description: "Heidi Data Collection Athena DB"
 
 # Create an AWS QuickSight DataSource for DataCollection
-  HeidiQSDataSource:
+  HeidiQSDataSourceV2:
     Condition: DeployDataCollectionComponents
     Type: AWS::QuickSight::DataSource
     Properties:

--- a/src/Setup/utils/DataCollectionSetup.py
+++ b/src/Setup/utils/DataCollectionSetup.py
@@ -31,9 +31,8 @@ def tag():
     
     return tags
 
-# Call the tag function to get the tags dictionary
-tags_dict = tag()
-
+# Initialize tags_dict - will be populated in setup()
+tags_dict = {}
 
 #Get Current Region
 def get_default_region():
@@ -332,6 +331,10 @@ def read_parameters(file_path):
     }
 
 def setup():
+    # Get tag information from user
+    global tags_dict
+    tags_dict = tag()
+    
     file_path = 'utils/ParametersDataCollection.txt'
 
     if os.path.exists(file_path):

--- a/src/Setup/utils/MemberSetup.py
+++ b/src/Setup/utils/MemberSetup.py
@@ -3,6 +3,36 @@ import subprocess
 from botocore.exceptions import ClientError
 import os
 
+# Get Tag
+def tag():
+    """Get multiple tag key-value pairs from user input"""
+    tags = {}
+    
+    # Get the first tag with defaults
+    tag_key = input("Enter the first tag key (Hit enter to use default: 'App'): ") or "App"
+    tag_value = input(f"Enter the value for '{tag_key}' (Hit enter to use default: 'Heidi'): ") or "Heidi"
+    tags[tag_key] = tag_value
+    
+    # Allow user to add more tags
+    while True:
+        add_more = input("Do you want to add another tag? (yes/no): ").lower().strip()
+        if add_more in ['yes', 'y']:
+            tag_key = input("Enter tag key: ").strip()
+            if tag_key:
+                tag_value = input(f"Enter value for '{tag_key}': ").strip()
+                tags[tag_key] = tag_value
+            else:
+                print("Tag key cannot be empty. Skipping...")
+        elif add_more in ['no', 'n']:
+            break
+        else:
+            print("Invalid input. Please enter 'yes' or 'no'.")
+    
+    return tags
+
+# Call the tag function to get the tags dictionary
+tags_dict = tag()
+
 # Get Current Account ID
 def get_account_id():
     # Get the AWS account ID for Unique names
@@ -30,7 +60,6 @@ def print_boxed_text(text):
     for line in lines:
         print(f' {line.ljust(max_length)} ')
     print('═' * (max_length + 2))
-
 
 # deploy stack
 def deploy_stack(command):
@@ -63,10 +92,13 @@ def setup():
                 DataCollectionRegion={parameters_dict['DataCollectionRegion']} \
                 ResourcePrefix={parameters_dict['ResourcePrefix']}"
 
+    # Format tags for deployment
+    tags = " ".join([f"{key}={value}" for key, value in tags_dict.items()])
+
     for region in DeploymentRegionHealth.split(','):
         stack_name = f"{parameters_dict['ResourcePrefix']}HealthModule-member-{get_account_id()}-{region}"
         command = f"sam deploy --stack-name {stack_name} --region {region} --parameter-overrides {parameters} \
-            --template-file ../HealthModule/HealthModuleCollectionSetup.yaml --capabilities CAPABILITY_NAMED_IAM --disable-rollback"
+            --template-file ../HealthModule/HealthModuleCollectionSetup.yaml --tags {tags} --capabilities CAPABILITY_NAMED_IAM --disable-rollback"
         # Deploy Stack
         deploy_stack(command)
 

--- a/src/Setup/utils/MemberSetup.py
+++ b/src/Setup/utils/MemberSetup.py
@@ -30,8 +30,8 @@ def tag():
     
     return tags
 
-# Call the tag function to get the tags dictionary
-tags_dict = tag()
+# Initialize tags_dict - will be populated in setup()
+tags_dict = {}
 
 # Get Current Account ID
 def get_account_id():
@@ -81,6 +81,10 @@ def get_user_input():
 
 # setup
 def setup():
+    # Get tag information from user
+    global tags_dict
+    tags_dict = tag()
+    
     parameters_dict = {}
     DataCollectionAccountID, DataCollectionRegion, DeploymentRegionHealth, ResourcePrefix = get_user_input()
 


### PR DESCRIPTION
*Issue #, if available:*

This supports adding multiple tag pairs to resource of both datacollection functionality and membersetup functionality

*Description of changes:*

support multiple user inputed tag 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
